### PR TITLE
Update blast.py

### DIFF
--- a/VirID/external/blast.py
+++ b/VirID/external/blast.py
@@ -84,8 +84,11 @@ class Diamond(object):
         else:
             args = ['diamond','blastx', '-q', origin_file, '-d', self.database_path, '-o', 
                  output_tsv, '-e', '1E-4', '-k', str(1), '-p', str(self.threads),'-f',str(6)]
-        for a in self.out_type:
-            args.append(a)
+        
+        if model != "makedb":
+            for a in self.out_type:
+                args.append(a)
+                
         diamond_log = output_tsv+"_log.txt"
         with open(diamond_log, 'a+') as f_out_err:
             proc = subprocess.Popen(
@@ -96,7 +99,7 @@ class Diamond(object):
             self.logger.error(
                 'An error was encountered while running Diamond.')
             raise ExternalException('Diamond returned a non-zero exit code.')
-        if not os.path.isfile(output_tsv):
+        if model != "makedb" and not os.path.isfile(output_tsv):
             self.logger.error(
                 'An error was encountered while running Diamond.')
             raise ExternalException(


### PR DESCRIPTION
Resolved two issues that causes runtime exceptions during direct use of phylogenetic_analysis stage.

1. VirID incorrectly appends the out_type to the diamond makedb command, which causes a runtime exception when diamond is invoked.
2. VirID always looks for the presence of an output TSV file, even when the makedb code-path will not create one.
